### PR TITLE
Create a dockerfile for easy, sandboxed execution of the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# USAGE:
+#   TAG=$(git rev-parse --short HEAD)
+#   docker build --tag "catphish:${TAG}" .
+#   docker run --rm=true "catphish:${TAG}" --Domain ring0labs.com --All
+FROM ruby:2.3.4-alpine
+
+# Install it into the /opt/ dir
+WORKDIR /opt/catphish
+ADD * /opt/catphish/
+RUN bundle install
+
+# Use the script as the entrypoint so we can supply args directly to the docker daemon
+# See https://serverfault.com/a/647790
+ENTRYPOINT ["/opt/catphish/catphish.rb"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,42 @@ Options:
   -P, --Punycode                             Use the punycode method.
   -h, --help                                 Show this message
 ```
+
+## Docker
+
+You can also run the tool with Docker! This lets you try it out without any of the required dependencies (ruby), except
+Docker itself. This presumes that you have the docker daemon installed. If not, see
+[Docker's documentation](https://docs.docker.com/engine/installation/).
+
+First, build the container
+
+```
+$ cd path/to/repository
+
+# Generate a tag so we know how to find the container later to run it. You can use anything (latest is common);
+# here the git hash is used.
+$ TAG=$(git rev-parse --short HEAD)
+
+# Run the build
+$ docker build --tag "catphish:${TAG}" .
+
+# Eventually docker will print something like:
+#
+#   Successfully built 8f0b8bfe0c41
+#   Successfully tagged catphish:f947517
+
+```
+
+Perfect! Now, you can execute catphish via Docker:
+
+```
+$ docker run \
+    --rm=true \
+    "catphish:${TAG}" \
+        --Domain ring0labs.com \
+        --All
+```
+
 # In Action
 
 ![alt tag](https://github.com/ring0lab/catphish/blob/master/image1.png)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ bundle install
 + New option allows a user to choose a specific set of top-level domains
 
 # Current Algorithms
-* SingularOrPluralise 
+* SingularOrPluralise
 * prependOrAppend
 * doubleExtensions
 * mirrorization


### PR DESCRIPTION
Linux containers are a primitive for executing processes in a sandbox
environment through a combination of linux namespaces and cgroups.
Docker is the most popular implementation of this abstraction, and comes
with a reasonable behaviour in which it isolates a process with these
namespaces and with seccomp, but does not (by default) apply cgroup
limits. However, it offers a nice chroot style environment where the
application can be trivially spun up and executed.

This commit adds a Dockerfile, which will successfully build the
program and allow it to be executed. Instructions for executing it are
documented in comments in the Dockerfile itself, but should be familiar
to most regular docker users.